### PR TITLE
Add tweet history retrieval using snscrape

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -43,7 +43,12 @@ def main():
     else:
         print("\nHistory:")
         for entry in history:
-            print(f"- {entry['timestamp']} | {entry['url']}")
+            line = f"- {entry['timestamp']} | {entry.get('type', 'entry')} | {entry['url']}"
+            print(line)
+            if 'user' in entry:
+                print(f"  user: {entry['user']}")
+            if entry.get('mentions'):
+                print(f"  mentions: {', '.join(entry['mentions'])}")
 
 if __name__ == "__main__":
     main()

--- a/app/registry.py
+++ b/app/registry.py
@@ -1,9 +1,9 @@
-from .twitter_x import get_current_user_info_x
+from .twitter_x import get_current_user_info_x, get_user_history_x
 
 PLATFORMS = {
     "x": {
         "get_current_user_info": get_current_user_info_x,
-        # History lookup can be swapped in later; None indicates not implemented
-        "get_user_history": None
+        # History lookup returns first tweet and its earliest reply
+        "get_user_history": get_user_history_x
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 streamlit
 tqdm
 waybackpy
+snscrape


### PR DESCRIPTION
## Summary
- fetch first tweet and earliest reply using snscrape to infer prior handles
- expose history function via CLI
- document snscrape requirement

## Testing
- `pip install -r requirements.txt`
- `python -m app.cli x jack` *(fails: ProxyError 403 when reaching external services)*

------
https://chatgpt.com/codex/tasks/task_e_689e0cf6453483259670795cff9d922d